### PR TITLE
Fix atom.xml feed errors

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -9,20 +9,18 @@ eleventyExcludeFromCollections: true
  <link href="{{ site.url }}/atom.xml" rel="self"/>
  <link href="{{ site.url }}"/>
  <updated>{{ site.time | date_to_xmlschema }}</updated>
- <id>{{ site.url }}</id>
+ <id>{{ site.url }}/</id>
  <author>
    <name>{{ site.author.name }}</name>
-   <email>{{ site.author.email }} </email>
+   <email>{{ site.author.email }}</email>
  </author>
  {% for post in collections.posts %}
  <entry>
    <title>{{ post.data.title | xml_escape }}</title>
    <link href="{{ site.url }}{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
-   <id>{{ site.url }}{{ post.id }}</id>
-  <content type="html" xml:base="{{ site.url }}{{ post.url }}"><![CDATA[
-    {{ post.content | xml_escape }}
-  ]]></content>
+   <id>{{ site.url }}{{ post.url }}</id>
+  <content type="html"><![CDATA[{{ post.content }}]]></content>
  </entry>
  {% endfor %}
 </feed>

--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -102,6 +102,21 @@ module.exports = (eleventyConfig) => {
     }
   );
 
+  eleventyConfig.addLiquidFilter("date_to_xmlschema", function (input) {
+    const date = new Date(input);
+    return date.toISOString();
+  });
+
+  eleventyConfig.addLiquidFilter("xml_escape", function (input) {
+    if (!input) return "";
+    return input
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&apos;");
+  });
+
   let markdownLib = markdownIt({ html: true, linkify: true }).use(
     markdownItAttrs,
     {


### PR DESCRIPTION
   - Add missing date_to_xmlschema and xml_escape Liquid filters
   - Fix invalid post.id reference (changed to post.url)
   - Remove redundant xml_escape from CDATA content block
   - Keep xml_escape for title element (required outside CDATA)

Should now validate with https://validator.w3.org/feed/check.cgi